### PR TITLE
Fixing Fatal Error during compilation M2.3.3

### DIFF
--- a/Plugin/CatalogImportExport/Model/Import/Product.php
+++ b/Plugin/CatalogImportExport/Model/Import/Product.php
@@ -2,7 +2,6 @@
 
 namespace MagePal\LinkProduct\Plugin\CatalogImportExport\Model\Import;
 
-use Magento\CatalogImportExport\Model\Import\Product;
 use MagePal\LinkProduct\Model\Product\Link;
 
 /**
@@ -18,7 +17,7 @@ class Product
      * @param $result
      * @return mixed
      */
-    public function afterGetLinkNameToId(Product $subject, $result)
+    public function afterGetLinkNameToId(\Magento\CatalogImportExport\Model\Import\Product $subject, $result)
     {
         $result['_accessory_'] = Link::LINK_TYPE_ACCESSORY;
         return $result;


### PR DESCRIPTION
Previous commit throws a Fatal Error for me during compilation (2.3.3) :

> Cannot declare class MagePal\LinkProduct\Plugin\CatalogImportExport\Model\Import\Product because the name is already in use in vendor/magepal/link-product/Plugin/CatalogImportExport/Model/Import/Product.php on line 11.